### PR TITLE
Trust unknown Go versions

### DIFF
--- a/deps/vendorable.go
+++ b/deps/vendorable.go
@@ -33,8 +33,8 @@ func Vendorable(verbose bool) error {
 	if err != nil {
 		if verbose {
 			fmt.Printf("\n%s\n", err)
-			return nil
 		}
+		return nil
 	}
 
 	if version.LessThan(go15) {


### PR DESCRIPTION
Currently the `verbose` flag has the side effect of trusting unknown Go versions. Unknown versions should always be trusted even if verbose is not set.