### PR TITLE
Locking single dependencies and pruning the lock file

### DIFF
--- a/deps/prune.go
+++ b/deps/prune.go
@@ -15,7 +15,8 @@ import (
 
 // Prune takes a deptree and verbose option and returns the number of
 // directories and files removed.
-func Prune(deptree []string, verbose bool) (dirs, files int) {
+func Prune(deptree []string, verbose bool) (dirs, files int, pruned []string) {
+	pruned = make([]string, 0, len(deptree))
 
 	if verbose {
 		fmt.Print("\nprune vendored packages... ")
@@ -33,6 +34,7 @@ func Prune(deptree []string, verbose bool) (dirs, files int) {
 
 			os.RemoveAll(w.Path())
 			w.SkipDir()
+			pruned = append(pruned, w.Path())
 			dirs++
 			continue
 		}
@@ -48,7 +50,7 @@ func Prune(deptree []string, verbose bool) (dirs, files int) {
 		fmt.Println("finished!")
 	}
 
-	return dirs, files
+	return dirs, files, pruned
 }
 
 func inDepTree(deptree []string, path string) bool {


### PR DESCRIPTION
If explicitly listing packages to vendor as command line arguments with the `-l` option, do not clean `vendor` directory; just add the new dependencies to the `vendor.yml` lock file.

Also, if using the `--prune` flag with the `-l` flag, dependencies that are pruned out are now removed from the `vendor.yml` lock file.

This resolves #48 and #50 