### PR TITLE
Resolve cwd symlinks before checking if we're in $GOPATH/src

### DIFF
--- a/deps/vendorable.go
+++ b/deps/vendorable.go
@@ -68,7 +68,13 @@ func checkGopath() error {
 	if err != nil {
 		return err
 	}
+
 	cwd, err = filepath.Abs(cwd)
+	if err != nil {
+		return err
+	}
+
+	cwd, err = filepath.EvalSymlinks(cwd)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I have a single GOPATH and symlinks to my projects in its root. where $GOPATH/foo -> $GOPATH/src/github.com/uberbrodt/foo. Code now checks if cwd is a symlink to something in $GOPATH/src.

Tested on Mac OS X