### PR TITLE
import/filters: add trailing filepath.Separator to prefix

### DIFF
--- a/imports/filters/filters.go
+++ b/imports/filters/filters.go
@@ -78,7 +78,7 @@ func Duplicates(pkgs []string) []string {
 // Local filters out any local packages.
 func Local(pkgs []string) []string {
 
-	prefix := projectImportPath()
+	prefix := projectImportPath() + string(filepath.Separator)
 	l := len(prefix)
 
 	var list []string


### PR DESCRIPTION
Otherwise, some non-local packages can be treated as local:
For example in project github.com/test/test, github.com/test/test-test will be
skipped from a scan.