### PR TITLE
Creating parents of repository download directory

### DIFF
--- a/deps/repos/download.go
+++ b/deps/repos/download.go
@@ -13,18 +13,26 @@ import (
 // of the repository is returned and the directory is created.
 func Download(r *Repo, dir, vendorRev string) (string, error) {
 
+	downloadDir := filepath.Join(dir, r.ImportPath)
+
 	// if that repo already exists, remove it
-	if err := os.RemoveAll(filepath.Join(dir, r.ImportPath)); err != nil {
+	if err := os.RemoveAll(downloadDir); err != nil {
+		return "", err
+	}
+
+	// create parents of the download dir, as Create() and CreateAtRev()
+	// expect it to exist
+	if err := os.MkdirAll(filepath.Dir(downloadDir), 0777); err != nil {
 		return "", err
 	}
 
 	// create the repository at a specific revision
 	if vendorRev == "" || vendorRev == "latest" {
-		if err := r.VCS.Create(filepath.Join(dir, r.ImportPath), r.URL); err != nil {
+		if err := r.VCS.Create(downloadDir, r.URL); err != nil {
 			return "", err
 		}
 	} else {
-		if err := r.VCS.CreateAtRev(filepath.Join(dir, r.ImportPath), r.URL, vendorRev); err != nil {
+		if err := r.VCS.CreateAtRev(downloadDir, r.URL, vendorRev); err != nil {
 			return "", err
 		}
 	}


### PR DESCRIPTION
This fixes problems when downloading some Bazaar repos. For example, consider a package containing a single file importing a Bazaar repo:
```go
package main
import "labix.org/v2/mgo/bson"
func main() {
}
```
Running `govend` inside this package yields an error:
```
$ govend
labix.org/v2/mgo bad ping: exit status 3
```
After some debugging, I found that the problem is due to the `bzr branch` command executed by govend to download the repo. It yields an error when the parent of the TO_LOCATION (see `bzr help branch`) does not exist.
This is the command executed by govend for the example above:
```
$ bzr branch https://launchpad.net/mgo/v2 vendor/labix.org/v2/mgo
bzr: ERROR: Parent of "vendor/labix.org/v2/mgo" does not exist.
$ echo $?
3
```
This may be fixed by creating the parents of the download folder with ` os.MkdirAll()` before the actual download. If it already exists, nothing happens; otherwise, it is created and govend may proceed with the download.